### PR TITLE
Resource segmentation updated

### DIFF
--- a/detnet-security.xml
+++ b/detnet-security.xml
@@ -521,6 +521,16 @@
             This can be performed using non-DetNet traffic that indirectly affects DetNet traffic
             (hardware resource exhaustion), or by using DetNet traffic from one DetNet flow that
             directly affects traffic from different DetNet flows.</t>
+		  <t>A specific example of a resource segmentation attack is by overloading the control 
+		  plane of the DetNet node, e.g., by overloading the exception path queue on the 
+		  router.  Thus, if any of the DetNet streams require or expect some packets to be punted 
+		  to the control plane or software data plane for processing, and there is a single queue 
+		  from the forwarding ASIC to a control plane or software data plane, then it could be 
+		  possible for non-DetNet flows to overload that shared queue such that punted packets 
+		  on the DetNet flows would end up being dropped. It should be noted that various attacks
+		  directed at the control plane (either the CPU of the DetNet node or a network controller) 
+		  can be used to compromise the network, but this document focuses on threats that are
+		  specific to deterministic networks.</t>
         </section>
         <section anchor="ReplicationThreat" title="Packet Replication and Elimination">
           <section title="Replication: Increased Attack Surface">


### PR DESCRIPTION

Comment from Robert Wilton:

(2) Overloading the exception path queue on the router.  E.g., if any of the
DetNet streams require/expect some packets to be punted to the control plane or
software data plane for processing (OAM related perhaps), and there is a single
queue from the forwarding ASIC to a control plane or software data plane, then
it could be possible for Non Detnet flows to overload that shared queue such
that punted packets on the DetNet flows would end up being dropped.

(2b) Related to (2), if an attacker was able to overload the router or linecard
CPU, e.g., through excessive management API requests, then it may be plausible
that it could also cause control plane processing of packets to be dropped, or
slowed down.

(2c) If the control plane is being managed by a separate controller than
presumably both (2) and (2b) could equally apply to getting traffic to a
controller, or processing events on the controller.


Response:

Regarding (2), (2b) and (2c) - we updated the "Resource Segmentation (Inter-segment Attack)" section in a way that we believe addresses these comments. We used a slightly modified version of the text that was proposed in the paragraph beginning with "(2) Overloading the exception...".